### PR TITLE
feature: support arbitrary use of $ref in the loaded spec

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ const parseSchema = (schemaName, docSchemas) => {
   return Enjoi.schema(docSchemas[schemaName]);
 }
 
-module.exports = filePath => {
-  const docSchemas = getSchemas(filePath);
+module.exports = async filePath => {
+  const docSchemas = await getSchemas(filePath);
 
   const joiSchemas = {};
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,9 +1,7 @@
-const { readFileSync } = require('fs');
-const { safeLoad } = require('js-yaml');
+const SwaggerParser = require('swagger-parser');
 
-const getSchemas = filePath => {
-  const openapi = readFileSync(filePath, 'utf8');
-  const doc = safeLoad(openapi);
+const getSchemas = async filePath => {
+  const doc = await SwaggerParser.dereference(filePath);
 
   return doc.components.schemas;
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "enjoi": "^6.0.0",
-    "js-yaml": "^3.10.0"
+    "swagger-parser": "^9.0.1"
   },
   "devDependencies": {
     "@hapi/joi": "^15.0.3",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,7 +3,10 @@ const Joi = require('@hapi/joi');
 const oas2joi = require('../index');
 
 describe('OpenAPI parser', () => {
-  const schemas = oas2joi('./test/oas/open-api.yml');
+  let schemas;
+  beforeAll(async () => {
+    schemas = await oas2joi('./test/oas/open-api.yml');
+  })
 
   describe('Success', () => {
     it('should have created schemas', () => {
@@ -39,6 +42,17 @@ describe('OpenAPI parser', () => {
         };
 
         const { error } = Joi.validate(obj, schemas.error);
+        expect(error).toEqual(null);
+      });
+
+      it('should allow $ref in schemas to be used for validation', () => {
+        const obj = {
+          demoErr1: 'foo',
+          demoRes1: 'A',
+          demoRes2: 'abc123'
+        };
+  
+        const { error } = Joi.validate(obj, schemas.referenced);
         expect(error).toEqual(null);
       });
   });

--- a/test/oas/open-api-ref.yml
+++ b/test/oas/open-api-ref.yml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  version: '1.0.0'
+  title: reference demo
+paths: {}
+components:
+  schemas:
+    referenced:
+      type: object
+      required:
+        - demoRes1
+        - demoRes2
+      properties:
+        demoRes1:
+          description: Demo
+          type: string
+          enum:
+            - A
+            - B
+            - C
+        demoRes2:
+          description: Demo
+          type: string

--- a/test/oas/open-api.yml
+++ b/test/oas/open-api.yml
@@ -46,3 +46,16 @@ components:
         - properties:
             aProperty:
               type: string
+    request:
+      type: object
+      properties:
+        foo:
+          type: string
+    referenced:
+      allOf:
+      - required:
+        - demoErr1
+        properties:
+          demoErr1:
+            type: string
+      - $ref: 'open-api-ref.yml#/components/schemas/referenced'


### PR DESCRIPTION
# Background
Fixing issue #9 and any `$ref` related issue in the input openapi spec. 

This PR basically replaces `js-yaml` by `swagger-parser`, which can load a openapi yaml spec, deference `$ref`s and outputs json schema, as `js-yaml` used to do.

# Issue
#9 

# Change Type
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist
- [x] The build is passing
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Version
Using [Semver](https://semver.org/) versioning, what version number should be bumped for this change?
- [x] Major
- [ ] Minor
- [ ] Patch

As the change require the `getSchemas` function to be async the exported function need to be async too, leading to a breaking api change :neutral_face: 

